### PR TITLE
Adjust the slope generator.

### DIFF
--- a/lib/example.js
+++ b/lib/example.js
@@ -6,19 +6,19 @@ class Example {
     return this.getNum(col-1, row-1) + this.getNum(col, row-1)
   }
 
-  static drawTree(row) {
-    let line = ''
+  static drawTree(total_rows) {
+    // Variable to store rows of column values we collect.
     let lines = []
-    for(let i=0; i<=row; i++) {
-      line += ' ' + this.getNum(i, row);
-      if (row == i) {
-        lines.push(line)
-        line = '';
-        this.drawTree(row-1)
+    // While we have not reached the total_rows required to render.
+    for(let curr_row = 0; curr_row <= total_rows; curr_row++) {
+      // While we still have columns in this row to display.
+      for(let curr_col = 0; curr_col <= curr_row; curr_col++) {
+        lines.push(this.getNum(curr_col, curr_row))
       }
-    }
-    for(let j=lines.length-1; j>=0; j--) {
-      console.log(lines[j])
+      // Print the contents of the row columns we just collected.
+      console.log( lines.join(" ") )
+      // Reset our lines array for the next row.
+      lines = []
     }
   }
 


### PR DESCRIPTION
This will print out each row as we have generated it so even with large `total_rows` requests you can at least see the progress that has been made so far.  The other benefit is since each row is pushed to the screen as it is solved it will avoid extra memory usage.
